### PR TITLE
Implement Builder Pattern (Add RequestBuilder)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/pkg/errors"
 	"github.com/ysyesilyurt/go-restclient/restclient"
+	"github.com/ysyesilyurt/go-restclient/restclient/v1"
 	"log"
 	"net/http"
 	"net/url"
@@ -23,7 +24,7 @@ type dummyBasicAuthenticator struct {
 	Username, Password string
 }
 
-func NewTestBasicAuthenticator(username, password string) restclient.Authenticator {
+func newTestBasicAuthenticator(username, password string) restclient.Authenticator {
 	return &dummyBasicAuthenticator{
 		Username: username,
 		Password: password,
@@ -39,14 +40,14 @@ func usage1() error {
 	var response dummyHttpResponse
 	headers := http.Header{"Content-Type": []string{"application/json"}, "Cookie": []string{"test-1234"}}
 	queryParams := url.Values{"tenantId": []string{"d90c3101-53bc-4c54-94db-21582bab8e17"}, "vectorId": []string{"1"}}
-	ri := restclient.NewRequestInfo("https", "ysyesilyurt.com", []string{"tasks", "1"}, &queryParams, &headers, nil)
-	req, err := restclient.NewRequest(ri)
+	ri := v1.NewRequestInfo("https", "ysyesilyurt.com", []string{"tasks", "1"}, &queryParams, &headers, nil)
+	req, err := v1.NewRequest(ri)
 	if err != nil {
 		return errors.Wrap(err, "Failed to construct http.Request out of RequestInfo")
 	}
 
-	client := restclient.NewHttpClient(true, 30*time.Second)
-	dri := restclient.NewDoRequestInfo(req, nil, &response)
+	client := v1.NewHttpClient(true, 30*time.Second)
+	dri := v1.NewDoRequestInfo(req, nil, &response)
 	err = client.Get(dri)
 	if err != nil {
 		return errors.Wrap(err, "Failed to do HTTP GET request")
@@ -63,19 +64,19 @@ func usage2() error {
 		Name: "1234",
 	}
 	headers := http.Header{"Content-Type": []string{"application/json"}, "Cookie": []string{"test-1234"}}
-	ri, err := restclient.NewRequestInfoFromRawURL("https://ysyesilyurt.com/tasks/1?tenantId=d90c3101-53bc-4c54-94db-21582bab8e17&vectorId=1", &headers, requestBody)
+	ri, err := v1.NewRequestInfoFromRawURL("https://ysyesilyurt.com/tasks/1?tenantId=d90c3101-53bc-4c54-94db-21582bab8e17&vectorId=1", &headers, requestBody)
 	if err != nil {
 		return errors.Wrap(err, "Failed to construct RequestInfo out of Raw URL")
 	}
 
-	req, err := restclient.NewRequest(ri)
+	req, err := v1.NewRequest(ri)
 	if err != nil {
 		return errors.Wrap(err, "Failed to construct http.Request out of RequestInfo")
 	}
 
-	client := restclient.NewHttpClient(true, 0)
-	auth := NewTestBasicAuthenticator("ysyesilyurt", "0123")
-	dri := restclient.NewDoRequestInfoWithTimeout(req, auth, &response, 15*time.Second)
+	client := v1.NewHttpClient(true, 0)
+	auth := newTestBasicAuthenticator("ysyesilyurt", "0123")
+	dri := v1.NewDoRequestInfoWithTimeout(req, auth, &response, 15*time.Second)
 	err = client.Post(dri)
 	if err != nil {
 		return errors.Wrap(err, "Failed to do HTTP GET request")
@@ -86,15 +87,41 @@ func usage2() error {
 func usage3() error {
 	var response dummyHttpResponse
 	headers := http.Header{"Content-Type": []string{"application/json"}, "Cookie": []string{"test-1234"}}
-	ri, err := restclient.NewRequestInfoFromRawURL("https://ysyesilyurt.com/tasks/1?tenantId=d90c3101-53bc-4c54-94db-21582bab8e17&vectorId=1", &headers, nil)
+	ri, err := v1.NewRequestInfoFromRawURL("https://ysyesilyurt.com/tasks/1?tenantId=d90c3101-53bc-4c54-94db-21582bab8e17&vectorId=1", &headers, nil)
 	if err != nil {
 		return errors.Wrap(err, "Failed to construct RequestInfo out of Raw URL")
 	}
 
-	auth := NewTestBasicAuthenticator("ysyesilyurt", "0123")
-	err = restclient.PerformGetRequest(ri, auth, &response, true, 30*time.Second)
+	auth := newTestBasicAuthenticator("ysyesilyurt", "0123")
+	err = v1.PerformGetRequest(ri, auth, &response, true, 30*time.Second)
 	if err != nil {
 		return errors.Wrap(err, "Failed to perform HTTP GET request")
+	}
+	return nil
+}
+
+func usageBuilder() error {
+	var response dummyHttpResponse
+	rawUrl := "https://ysyesilyurt.com/tasks/1?tenantId=d90c3101-53bc-4c54-94db-21582bab8e17&vectorId=1"
+	headers := http.Header{"Content-Type": []string{"application/json"}, "Cookie": []string{"test-1234"}}
+	testAuth := newTestBasicAuthenticator("ysyesilyurt", "0123")
+
+	req, reqErr := restclient.RequestBuilder().
+		RawUrl(rawUrl).
+		Header(&headers).
+		Auth(testAuth).
+		ResponseReference(&response).
+		LoggingEnabled(true).
+		Timeout(30 * time.Second).
+		Build()
+
+	if reqErr != nil {
+		return errors.Wrap(reqErr, "Failed to construct HTTP request")
+	}
+
+	reqErr = req.Get()
+	if reqErr != nil {
+		return errors.Wrap(reqErr, "Failed to perform HTTP GET request")
 	}
 	return nil
 }
@@ -105,12 +132,19 @@ func main() {
 	if err != nil {
 		log.Printf("Example usage1 failed, reason: %v", err)
 	}
+
 	err = usage2()
 	if err != nil {
 		log.Printf("Example usage2 failed, reason: %v", err)
 	}
+
 	err = usage3()
 	if err != nil {
 		log.Printf("Example usage3 failed, reason: %v", err)
+	}
+
+	err = usageBuilder()
+	if err != nil {
+		log.Printf("Example usageBuilder failed, reason: %v", err)
 	}
 }

--- a/restclient/basic_authenticator.go
+++ b/restclient/basic_authenticator.go
@@ -1,0 +1,21 @@
+package restclient
+
+import (
+	"net/http"
+)
+
+type BasicAuthenticator struct {
+	Username, Password string
+}
+
+func NewBasicAuthenticator(username, password string) Authenticator {
+	return &BasicAuthenticator{
+		Username: username,
+		Password: password,
+	}
+}
+
+func (ba BasicAuthenticator) Apply(request *http.Request) error {
+	request.SetBasicAuth(ba.Username, ba.Password)
+	return nil
+}

--- a/restclient/builder.go
+++ b/restclient/builder.go
@@ -1,0 +1,218 @@
+package restclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type HttpRequestBuilder struct {
+	hr HttpRequest
+	ri requestInfo
+}
+
+/* RequestBuilder builds a HttpRequest using the methods define to fill the fields for HttpRequest.
+There exists default values for some fields:
+- Timeout: 60 Seconds (defaultTimeoutDuration)
+- LoggingEnabled: true
+*/
+func RequestBuilder() HttpRequestBuilder {
+	return HttpRequestBuilder{
+		hr: HttpRequest{timeout: defaultTimeoutDuration, loggingEnabled: true},
+		ri: requestInfo{},
+	}
+}
+
+/* requestInfo is an internal type to ease things with HttpRequestBuilder */
+type requestInfo struct {
+	scheme       string       // scheme e.g. http
+	host         string       // host e.g. example.com
+	pathElements []string     // pathElements represents each component in the path that is separated by a slash (/) e.g. ['posts', '1']
+	header       *http.Header // header e.g {"Content-Type": []string{"application/json"}, "Cookie": []string{"test-1234"}}
+	bodyJson     interface{}  // bodyJson represents the unprocessed (to-be-marshalled) RequestBody which is going to be sent in Json form
+	body         io.Reader    // body represents RequestBody
+	queryParams  *url.Values  // queryParams e.g {"tenantId": []string{"d90c3101-53bc-4c54-94db-21582bab8e17"}, "vectorId": []string{"1"}}
+}
+
+func (hrb HttpRequestBuilder) RawUrl(rawUrl string) HttpRequestBuilder {
+	parsedUrl, err := url.Parse(rawUrl)
+	if err != nil {
+		errorLogger.Printf("Failed to Parse Given Raw URL! Leaving fields that is filled with Raw URL empty..., %v", err)
+		return hrb
+	}
+	hrb.ri.scheme = parsedUrl.Scheme
+	hrb.ri.host = parsedUrl.Host
+	hrb.ri.pathElements = strings.Split(parsedUrl.Path, "/")[1:]
+	queryParams := parsedUrl.Query()
+	hrb.ri.queryParams = &queryParams
+	return hrb
+}
+
+func (hrb HttpRequestBuilder) Scheme(scheme string) HttpRequestBuilder {
+	hrb.ri.scheme = scheme
+	return hrb
+}
+
+func (hrb HttpRequestBuilder) Host(host string) HttpRequestBuilder {
+	hrb.ri.host = host
+	return hrb
+}
+
+func (hrb HttpRequestBuilder) PathElements(pe []string) HttpRequestBuilder {
+	hrb.ri.pathElements = pe
+	return hrb
+}
+
+func (hrb HttpRequestBuilder) QueryParams(qp *url.Values) HttpRequestBuilder {
+	hrb.ri.queryParams = qp
+	return hrb
+}
+
+func (hrb HttpRequestBuilder) Header(header *http.Header) HttpRequestBuilder {
+	hrb.ri.header = header
+	return hrb
+}
+
+/* HttpRequestBuilder.Body is the direct io.Reader RequestBody to be applied to the request */
+func (hrb HttpRequestBuilder) Body(body io.Reader) HttpRequestBuilder {
+	hrb.ri.body = body
+	return hrb
+}
+
+/* HttpRequestBuilder.BodyJson represents the unprocessed (to-be-marshalled) RequestBody which is going to be sent in Json form.
+Use this builder method if RequestBody will be sent in Json form. This method accepts RequestBody directly in its raw form
+(no need for any marshalling or io.Reader conversion ops) */
+func (hrb HttpRequestBuilder) BodyJson(bodyJson interface{}) HttpRequestBuilder {
+	hrb.ri.bodyJson = bodyJson
+	return hrb
+}
+
+func (hrb HttpRequestBuilder) Auth(auth Authenticator) HttpRequestBuilder {
+	hrb.hr.auth = auth
+	return hrb
+}
+
+func (hrb HttpRequestBuilder) ResponseReference(respRef interface{}) HttpRequestBuilder {
+	hrb.hr.respReference = respRef
+	return hrb
+}
+
+/* HttpRequestBuilder.Request provides directly sets internal http.Request with the provided one. Use this if you
+consider using this builder with a pre-prepared http.Request object */
+func (hrb HttpRequestBuilder) Request(req *http.Request) HttpRequestBuilder {
+	r := func() http.Request {
+		return *req
+	}()
+	hrb.hr.request = &r
+	return hrb
+}
+
+/* HttpRequestBuilder.Timeout decides on the timeout value to be used for the response. Default is 60 (defaultTimeoutDuration) seconds. */
+func (hrb HttpRequestBuilder) Timeout(timeout time.Duration) HttpRequestBuilder {
+	hrb.hr.timeout = timeout
+	return hrb
+}
+
+/* HttpRequestBuilder.LoggingEnabled decides whether request result should be logged or not. Default is true. */
+func (hrb HttpRequestBuilder) LoggingEnabled(enabled bool) HttpRequestBuilder {
+	hrb.hr.loggingEnabled = enabled
+	return hrb
+}
+
+func (hrb HttpRequestBuilder) Build() (*HttpRequest, RequestError) {
+	var err error
+
+	if hrb.hr.request == nil {
+		err = validateRequiredRequestFields(hrb.ri)
+		if err != nil {
+			return nil, NewRequestBuildError(InvalidRequestErr, errors.Wrap(err, "Invalid request fields"))
+		}
+	}
+
+	// Marshal JSON RequestBody if exists. Note that io.Reader body is prioritized over json body.
+	bodyReader := hrb.ri.body
+	if hrb.ri.body == nil && hrb.ri.bodyJson != nil {
+		marshalled, err := json.Marshal(hrb.ri.bodyJson)
+		if err != nil {
+			return nil, NewRequestBuildError(InvalidRequestErr, errors.Wrap(err, "Failed to marshal request body"))
+		}
+		bodyReader = bytes.NewReader(marshalled)
+	}
+
+	if hrb.hr.request == nil {
+		// Build the request object if request is nil
+		// Construct URL by escaping components
+		escapedURLString := buildEndpoint(hrb.ri.scheme, hrb.ri.host, hrb.ri.pathElements)
+		hrb.hr.request, err = http.NewRequest("", escapedURLString, bodyReader)
+		if err != nil {
+			return nil, NewRequestBuildError(InvalidRequestErr, errors.Wrap(err, "Failed to construct http.Request"))
+		}
+	} else if bodyReader != nil {
+		// If request is not nil, set body
+		hrb.hr.request.Body = ioutil.NopCloser(bodyReader)
+	}
+
+	hrb.hr.request.Close = true
+
+	// Validate that resulting URL path in request is valid
+	if len(hrb.ri.pathElements) != 0 {
+		if _, err = url.ParseRequestURI(hrb.hr.request.URL.Path); err != nil {
+			return nil, NewRequestBuildError(InvalidRequestErr, errors.Wrap(err, "Invalid Request URI"))
+		}
+	}
+
+	// Set queryParams if exists
+	if hrb.ri.queryParams != nil {
+		hrb.hr.request.URL.RawQuery = hrb.ri.queryParams.Encode()
+	}
+
+	setHeaderIfExists := func(key string, value []string) {
+		if key != "" && len(value) != 0 {
+			for _, v := range value {
+				hrb.hr.request.Header.Add(key, v)
+			}
+		}
+	}
+
+	// Set custom headers
+	if hrb.ri.header != nil {
+		for hName, hValue := range *hrb.ri.header {
+			setHeaderIfExists(hName, hValue)
+		}
+	}
+
+	return &hrb.hr, nil
+}
+
+/* validateRequiredRequestFields ensures that built HttpRequest object has its required fields set to a nonzero value */
+func validateRequiredRequestFields(ri requestInfo) error {
+	if ri.scheme == "" {
+		return errors.New("Empty request scheme")
+	}
+
+	if ri.host == "" {
+		return errors.New("Empty request host")
+	}
+
+	return nil
+}
+
+/* buildEndpoint performs proper URL Escaping on path params and delivers the safe formatted endpoint string */
+func buildEndpoint(scheme, host string, pathElements []string) string {
+	urlFormat := strings.Builder{}
+	sanitizedUrlElements := make([]interface{}, len(pathElements))
+	escapedSchemeHost := fmt.Sprintf("%s://%s", url.PathEscape(scheme), url.PathEscape(host))
+	urlFormat.WriteString(escapedSchemeHost)
+	for i, ue := range pathElements {
+		sanitizedUrlElements[i] = url.PathEscape(ue)
+		urlFormat.WriteString("/%s")
+	}
+	return fmt.Sprintf(urlFormat.String(), sanitizedUrlElements...)
+}

--- a/restclient/builder_test.go
+++ b/restclient/builder_test.go
@@ -1,0 +1,181 @@
+package restclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	. "github.com/smartystreets/goconvey/convey"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestHttpRequestBuilder(t *testing.T) {
+	var testResp testHttpResponse
+	trb := testRequestBody{
+		TestId:   123,
+		TestName: "1234",
+	}
+	testAuth := newTestBasicAuthenticator("detection", "0123")
+	wanted := createTestNewRequestWantArgs(trb)
+	type args struct {
+		RawUrl         string
+		Scheme         string
+		Host           string
+		PathComponents []string
+		Headers        *http.Header
+		Body           io.Reader
+		BodyJson       interface{}
+		QueryParams    *url.Values
+		Auth           Authenticator
+		ResponseRef    interface{}
+		Timeout        time.Duration
+		LoggingEnabled bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want HttpRequest
+	}{
+		{
+			name: "Request without Body and pathParams, but has 2 query params",
+			args: args{
+				Scheme:         "https",
+				Host:           "picus-detection.com",
+				PathComponents: []string{"assessments", "scroll"},
+				Headers:        &http.Header{"Content-Type": []string{"application/json"}, "Cookie": []string{"test-1234"}, "Xsrf-Token": []string{"CSRFToken"}, "X-Xsrf-Token": []string{"ab4f3712-1cd4-4860-9fec-1276866403da"}},
+				BodyJson:       nil,
+				QueryParams:    &url.Values{"tenantId": []string{"d90c3101-53bc-4c54-94db-21582bab8e17"}, "vectorId": []string{"1"}},
+				ResponseRef:    testResp,
+			},
+			want: HttpRequest{
+				request:        wanted[0],
+				auth:           nil,
+				respReference:  testResp,
+				timeout:        defaultTimeoutDuration,
+				loggingEnabled: false,
+			},
+		},
+		{
+			name: "Request with Json Body and pathParams, but has no query params",
+			args: args{
+				Scheme:         "https",
+				Host:           "picus-detection.com",
+				PathComponents: []string{"assessments", "scroll", "d90c3101-53bc-4c54-94db-21582bab8e17", "1"},
+				Headers:        &http.Header{"Content-Type": []string{"application/json"}, "Cookie": []string{"test-1234"}},
+				BodyJson:       trb,
+				ResponseRef:    testResp,
+			},
+			want: HttpRequest{
+				request:        wanted[1],
+				auth:           nil,
+				respReference:  testResp,
+				timeout:        defaultTimeoutDuration,
+				loggingEnabled: false,
+			},
+		},
+		{
+			name: "Request that is constructed with RawUrl, Reader Body and has other fields",
+			args: args{
+				RawUrl:  fmt.Sprintf("https://picus-detection.com/assessments/scroll/d90c3101-53bc-4c54-94db-21582bab8e17/1?tenantId=%s&vectorId=%s", "d90c3101-53bc-4c54-94db-21582bab8e17", "1"),
+				Headers: &http.Header{"Content-Type": []string{"application/json"}, "Cookie": []string{"test-1234"}},
+				Body: func() io.Reader {
+					m, _ := json.Marshal(trb)
+					return bytes.NewReader(m)
+				}(),
+				Auth:           testAuth,
+				ResponseRef:    testResp,
+				Timeout:        5 * time.Second,
+				LoggingEnabled: true,
+			},
+			want: HttpRequest{
+				request:        wanted[2],
+				auth:           testAuth,
+				respReference:  testResp,
+				timeout:        5 * time.Second,
+				loggingEnabled: true,
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		var req *HttpRequest
+		var reqErr RequestError
+		t.Run(tt.name, func(t *testing.T) {
+			if i == 2 {
+				req, reqErr = RequestBuilder().
+					RawUrl(tt.args.RawUrl).
+					Header(tt.args.Headers).
+					Body(tt.args.Body).
+					Auth(tt.args.Auth).
+					ResponseReference(tt.args.ResponseRef).
+					Timeout(tt.args.Timeout).
+					LoggingEnabled(tt.args.LoggingEnabled).
+					Build()
+			} else {
+				req, reqErr = RequestBuilder().
+					Scheme(tt.args.Scheme).
+					Host(tt.args.Host).
+					PathElements(tt.args.PathComponents).
+					QueryParams(tt.args.QueryParams).
+					Header(tt.args.Headers).
+					BodyJson(tt.args.BodyJson).
+					Auth(tt.args.Auth).
+					ResponseReference(tt.args.ResponseRef).
+					LoggingEnabled(tt.args.LoggingEnabled).
+					Build()
+			}
+			Convey("Requests should be constructed without err and with proper fields", t, func() {
+				So(reqErr, ShouldBeNil)
+				So(req.request.URL.Scheme, ShouldEqual, tt.want.request.URL.Scheme)
+				So(req.request.URL.Host, ShouldEqual, tt.want.request.URL.Host)
+				So(req.request.URL.Path, ShouldEqual, tt.want.request.URL.Path)
+				So(req.request.Header, ShouldResemble, tt.want.request.Header)
+				So(req.request.Body, ShouldResemble, tt.want.request.Body)
+				So(req.request.URL.RawQuery, ShouldEqual, tt.want.request.URL.RawQuery)
+				So(req.respReference, ShouldResemble, tt.want.respReference)
+				So(req.timeout, ShouldEqual, tt.want.timeout)
+				So(req.auth, ShouldResemble, tt.args.Auth)
+				So(req.loggingEnabled, ShouldEqual, tt.args.LoggingEnabled)
+			})
+		})
+	}
+}
+
+func createTestNewRequestWantArgs(trb testRequestBody) []*http.Request {
+	// Construct first resulting request
+	want1, err := http.NewRequest("", "https://picus-detection.com/assessments/scroll?tenantId=d90c3101-53bc-4c54-94db-21582bab8e17&vectorId=1", nil)
+	if err != nil {
+		log.Fatalf("Could not construct first request want argument %s", err.Error())
+	}
+	want1.Header.Set("Content-Type", "application/json")
+	want1.Header.Set("Cookie", "test-1234")
+	want1.Header.Set("Xsrf-Token", "CSRFToken")
+	want1.Header.Set("X-Xsrf-Token", "ab4f3712-1cd4-4860-9fec-1276866403da")
+
+	// Construct second resulting request
+	marshalled, err := json.Marshal(trb)
+	if err != nil {
+		log.Fatalf("Could not marshal request body for the second request want argument %s", err.Error())
+	}
+
+	want2, err := http.NewRequest("", "https://picus-detection.com/assessments/scroll/d90c3101-53bc-4c54-94db-21582bab8e17/1", bytes.NewReader(marshalled))
+	if err != nil {
+		log.Fatalf("Could not construct second request want argument %s", err.Error())
+	}
+	want2.Header.Set("Content-Type", "application/json")
+	want2.Header.Set("Cookie", "test-1234")
+
+	// Construct third resulting request
+	want3, err := http.NewRequest("", "https://picus-detection.com/assessments/scroll/d90c3101-53bc-4c54-94db-21582bab8e17/1?tenantId=d90c3101-53bc-4c54-94db-21582bab8e17&vectorId=1", bytes.NewReader(marshalled))
+	if err != nil {
+		log.Fatalf("Could not construct third request want argument %s", err.Error())
+	}
+	want3.Header.Set("Content-Type", "application/json")
+	want3.Header.Set("Cookie", "test-1234")
+
+	return []*http.Request{want1, want2, want3}
+}

--- a/restclient/errors.go
+++ b/restclient/errors.go
@@ -1,0 +1,123 @@
+package restclient
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"net/http"
+)
+
+var (
+	InvalidRequestErr         = errors.New("Invalid request error")
+	InvalidResponseBodyErr    = errors.New("Invalid response body error")
+	UnexpectedResponseCodeErr = errors.New("Unexpected HTTP response code")
+	HttpClientErr             = errors.New("Http client error")
+	UnauthorizedErr           = errors.New("Unauthorized - Authentication failed")
+	ForbiddenErr              = errors.New("Resource is forbidden, check your authentication token and permissions")
+	RecordNotFoundErr         = errors.New("Resource is not found")
+	ParseErr                  = errors.New("Not well-formatted request or missing fields")
+	TooManyRequestErr         = errors.New("Too many requests - Resource unavailable")
+	UnprocessableEntityErr    = errors.New("Syntactically correct but semantically incorrect request")
+	InternalServerErr         = errors.New("Internal server error")
+	ServiceUnavailableErr     = errors.New("Service unavailable")
+)
+
+type RequestError interface {
+	Error() string
+	GetTopLevelError() error   // GetTopLevelError returns top level error that originates the title
+	GetUnderlyingError() error // GetUnderlyingError returns underlying error that originates the message
+	GetTitle() string          // GetTitle returns top level error 'title' referring to message
+	GetMessage() string        // GetMessage returns detailed error message for the request
+	GetStatusCode() int        // GetStatusCode returns status code for the request. '0' means request failed for some reason and can be checked using methods below
+	Timeout() bool             // Timeout returns if request failed due to a timeout
+	ConnectionError() bool     // ConnectionError returns if request failed due to a connection error (Failed to get response for some reason)
+	ResponseParseError() bool  // ResponseParseError returns if response of the request could not be parsed into given response reference variable
+	RequestBuildError() bool   // RequestBuildError returns if request could not be built due to some reason
+}
+
+type requestErrorImpl struct {
+	topLevelErr, err                                                  error
+	statusCode                                                        int
+	isTimeout, isConnectionErr, isResponseParseErr, isRequestBuildErr bool
+}
+
+func (r requestErrorImpl) GetTopLevelError() error {
+	return r.topLevelErr
+}
+
+func (r requestErrorImpl) GetUnderlyingError() error {
+	return r.err
+}
+
+func (r requestErrorImpl) GetTitle() string {
+	return r.topLevelErr.Error()
+}
+
+func (r requestErrorImpl) GetMessage() string {
+	return r.err.Error()
+}
+
+func (r requestErrorImpl) GetStatusCode() int {
+	return r.statusCode
+}
+
+func (r requestErrorImpl) Timeout() bool {
+	return r.isTimeout
+}
+
+func (r requestErrorImpl) ConnectionError() bool {
+	return r.isConnectionErr
+}
+
+func (r requestErrorImpl) ResponseParseError() bool {
+	return r.isResponseParseErr
+}
+
+func (r requestErrorImpl) RequestBuildError() bool {
+	return r.isRequestBuildErr
+}
+
+func (r requestErrorImpl) Error() string {
+	return fmt.Sprintf("%s - %s - Status Code: %d", r.GetTitle(), r.GetMessage(), r.GetStatusCode())
+}
+
+func NewRequestError(topLevelErr, err error, statusCode int) RequestError {
+	return &requestErrorImpl{
+		topLevelErr: topLevelErr,
+		err:         err,
+		statusCode:  statusCode,
+	}
+}
+
+func NewRequestTimeoutError(topLevelErr, err error) RequestError {
+	return &requestErrorImpl{
+		topLevelErr:     topLevelErr,
+		err:             err,
+		statusCode:      http.StatusRequestTimeout,
+		isTimeout:       true,
+		isConnectionErr: true,
+	}
+}
+
+func NewRequestConnectionError(topLevelErr, err error) RequestError {
+	return &requestErrorImpl{
+		topLevelErr:     topLevelErr,
+		err:             err,
+		isConnectionErr: true,
+	}
+}
+
+func NewRequestBuildError(topLevelErr, err error) RequestError {
+	return &requestErrorImpl{
+		topLevelErr:       topLevelErr,
+		err:               err,
+		isRequestBuildErr: true,
+	}
+}
+
+func NewRequestResponseParseError(topLevelErr, err error) RequestError {
+	return &requestErrorImpl{
+		topLevelErr:        topLevelErr,
+		err:                err,
+		isResponseParseErr: true,
+	}
+}

--- a/restclient/logger.go
+++ b/restclient/logger.go
@@ -1,0 +1,38 @@
+package restclient
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+const (
+	red color = iota + 31
+	green
+	yellow
+	blue
+)
+
+// color represents a text color.
+type color uint8
+
+// Add adds the coloring to the given string.
+func (c color) add(s string) string {
+	return fmt.Sprintf("\x1b[%dm%s\x1b[0m", uint8(c), s)
+}
+
+/* infoLogger, debugLogger, warningLogger and errorLogger are internal private loggers to log requests
+3rd party go logging libraries have been avoided intentionally to omit unnecessary dependencies on the user. */
+var (
+	infoLogger    *log.Logger
+	debugLogger   *log.Logger
+	warningLogger *log.Logger
+	errorLogger   *log.Logger
+)
+
+func init() {
+	infoLogger = log.New(os.Stdout, blue.add(" [ INFO ] "), log.Ldate|log.Ltime|log.Lshortfile)
+	debugLogger = log.New(os.Stdout, green.add(" [ DEBUG ] "), log.Ldate|log.Ltime|log.Lshortfile)
+	warningLogger = log.New(os.Stdout, yellow.add(" [ WARN ] "), log.Ldate|log.Ltime|log.Lshortfile)
+	errorLogger = log.New(os.Stdout, red.add(" [ ERROR ] "), log.Ldate|log.Ltime|log.Lshortfile)
+}

--- a/restclient/request.go
+++ b/restclient/request.go
@@ -1,0 +1,248 @@
+package restclient
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const defaultTimeoutDuration = 60 * time.Second
+
+/* HttpRequest is exported request object that contains all the necessary things to perform an HttpRequest,
+can be created using HttpRequestBuilder  */
+type HttpRequest struct {
+	request        *http.Request // internal http.Request object
+	auth           Authenticator // Custom Authentication Strategy to apply to the request
+	respReference  interface{}   // Object reference to map the response of the request
+	timeout        time.Duration // timeout value to be used for the request
+	loggingEnabled bool          // log the result of the request if loggingEnabled
+}
+
+func newHttpClient(timeout time.Duration) *http.Client {
+	tr := &http.Transport{
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+		DisableKeepAlives: true,
+	}
+	client := &http.Client{
+		Transport: tr,
+		Timeout: func() time.Duration {
+			if timeout < 0 {
+				return defaultTimeoutDuration
+			}
+			return timeout
+		}(),
+	}
+	return client
+}
+
+/* YieldRequest returns the underlying *http.Request object */
+func (hr HttpRequest) YieldRequest() *http.Request {
+	return hr.request
+}
+
+/* Get performs an HTTP GET request using the provided HttpRequest fields. Applies HttpRequest.auth directly to the resulting
+request on it (nil auth means no auth). Decodes any response into HttpRequest.respReference. Also uses HttpRequest.timeout value
+as the request timeout value, Zero (0) means no timeout. Returns a RequestError implying the result of the call */
+func (hr HttpRequest) Get() RequestError {
+	return hr.do(hr.request, http.MethodGet, hr.auth, hr.respReference, hr.timeout)
+}
+
+/* Post performs an HTTP GET request using the provided HttpRequest fields. Applies HttpRequest.auth directly to the resulting
+request on it (nil auth means no auth). Decodes any response into HttpRequest.respReference. Also uses HttpRequest.timeout value
+as the request timeout value, Zero (0) means no timeout. Returns a RequestError implying the result of the call */
+func (hr HttpRequest) Post() RequestError {
+	return hr.do(hr.request, http.MethodPost, hr.auth, hr.respReference, hr.timeout)
+}
+
+/* Put performs an HTTP GET request using the provided HttpRequest fields. Applies HttpRequest.auth directly to the resulting
+request on it (nil auth means no auth). Decodes any response into HttpRequest.respReference. Also uses HttpRequest.timeout value
+as the request timeout value, Zero (0) means no timeout. Returns a RequestError implying the result of the call */
+func (hr HttpRequest) Put() RequestError {
+	return hr.do(hr.request, http.MethodPut, hr.auth, hr.respReference, hr.timeout)
+}
+
+/* Patch performs an HTTP GET request using the provided HttpRequest fields. Applies HttpRequest.auth directly to the resulting
+request on it (nil auth means no auth). Decodes any response into HttpRequest.respReference. Also uses HttpRequest.timeout value
+as the request timeout value, Zero (0) means no timeout. Returns a RequestError implying the result of the call */
+func (hr HttpRequest) Patch() RequestError {
+	return hr.do(hr.request, http.MethodPatch, hr.auth, hr.respReference, hr.timeout)
+}
+
+/* Delete performs an HTTP GET request using the provided HttpRequest fields. Applies HttpRequest.auth directly to the resulting
+request on it (nil auth means no auth). Decodes any response into HttpRequest.respReference. Also uses HttpRequest.timeout value
+as the request timeout value, Zero (0) means no timeout. Returns a RequestError implying the result of the call */
+func (hr HttpRequest) Delete() RequestError {
+	return hr.do(hr.request, http.MethodDelete, hr.auth, hr.respReference, hr.timeout)
+}
+
+func (hr HttpRequest) do(req *http.Request, method string, auth Authenticator, respRef interface{}, timeout time.Duration) RequestError {
+
+	setHeaderIfNotSetAlready := func(key, value string) {
+		if req.Header.Get(key) == "" && value != "" {
+			req.Header.Set(key, value)
+		}
+	}
+
+	// Set universal headers
+	setHeaderIfNotSetAlready("Accept", "application/json")
+	req.Method = method
+	switch method {
+	case http.MethodPut, http.MethodPatch, http.MethodPost:
+		setHeaderIfNotSetAlready("Content-Type", "application/json")
+	}
+
+	// Set Authorization header by applying specified authenticator's strategy if exists
+	if auth != nil {
+		err := auth.Apply(req)
+		if err != nil {
+			return NewRequestBuildError(InvalidRequestErr, errors.Wrap(err, "cannot apply authentication information to request"))
+		}
+	}
+
+	// Setup HttpClient
+	httpClient := newHttpClient(timeout)
+	doRequestAndTimeIfEnabled := func() (*http.Response, int64, error) {
+		var err error
+		var duration int64
+		var resp *http.Response
+
+		if hr.loggingEnabled {
+			startTime := time.Now()
+			resp, err = httpClient.Do(req)
+			duration = int64(time.Since(startTime) / time.Millisecond)
+		} else {
+			resp, err = httpClient.Do(req)
+		}
+		return resp, duration, err
+	}
+
+	logRequestIfEnabled := func(statusCode int, duration int64, err error) {
+		if hr.loggingEnabled {
+			logMsg := fmt.Sprintf("[status]: %d [duration-ms]: %d [url]: %s", statusCode, duration, req.URL.String())
+			if statusCode == 0 {
+				errorLogger.Printf("Request failed, %s, [err]: %v", logMsg, err)
+				return
+			}
+			infoLogger.Printf("Request finished %s", logMsg)
+		}
+	}
+
+	// Do Request (Time and Log it if enabled)
+	resp, duration, err := doRequestAndTimeIfEnabled()
+	if err != nil {
+		logRequestIfEnabled(0, duration, err)
+		urlError := err.(*url.Error)
+		if urlError.Timeout() {
+			return NewRequestTimeoutError(HttpClientErr, errors.Wrap(err, "Connection Error, Request Timed out"))
+		}
+		return NewRequestConnectionError(HttpClientErr, errors.Wrap(err, "Connection Error"))
+	}
+	logRequestIfEnabled(resp.StatusCode, duration, nil)
+	defer func() {
+		errBodyClose := resp.Body.Close()
+		if errBodyClose != nil {
+			if err == nil {
+				err = errors.Wrap(errBodyClose, "Failed to close response body")
+			} else {
+				errBodyClose = errors.Wrap(errBodyClose, "Failed to close response body")
+				err = errors.Wrap(err, errBodyClose.Error())
+			}
+		}
+	}()
+
+	// Handle Response Status Code
+	reqErr := prepareResponseError(resp)
+	if reqErr != nil {
+		return reqErr
+	}
+
+	// Read the body into respRef
+	if respRef != nil {
+		err = unmarshalResponseBody(resp, respRef)
+		if err != nil {
+			return NewRequestResponseParseError(InvalidRequestErr,
+				errors.Wrapf(err, "Failed to decode response body into given responseRef %T variable", respRef))
+		}
+	}
+	return nil
+}
+
+func prepareResponseError(response *http.Response) RequestError {
+	if response.StatusCode < 400 {
+		return nil
+	}
+
+	var topLevelErr error
+	responseMessage, err := getFailedResponseBody(response)
+	if err != nil {
+		return NewRequestResponseParseError(InvalidResponseBodyErr, errors.Wrap(err, "Failed to read response body"))
+	}
+	switch response.StatusCode {
+	case http.StatusUnauthorized:
+		topLevelErr = UnauthorizedErr
+	case http.StatusForbidden:
+		topLevelErr = ForbiddenErr
+	case http.StatusNotFound:
+		topLevelErr = RecordNotFoundErr
+	case http.StatusBadRequest:
+		topLevelErr = ParseErr
+	case http.StatusTooManyRequests:
+		topLevelErr = TooManyRequestErr
+	case http.StatusUnprocessableEntity:
+		topLevelErr = UnprocessableEntityErr
+	case http.StatusInternalServerError:
+		topLevelErr = InternalServerErr
+	case http.StatusServiceUnavailable:
+		topLevelErr = ServiceUnavailableErr
+	default:
+		topLevelErr = UnexpectedResponseCodeErr
+	}
+	return NewRequestError(topLevelErr, errors.New(responseMessage), response.StatusCode)
+}
+
+func getFailedResponseBody(response *http.Response) (string, error) {
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to convert response body to error")
+	}
+	return string(body), nil
+}
+
+func readerToByte(reader io.Reader) ([]byte, error) {
+	body, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func unmarshalResponseBody(response *http.Response, v interface{}) error {
+	return unmarshalReader(response.Body, v)
+}
+
+func unmarshalRequestBody(request *http.Request, v interface{}) error {
+	return unmarshalReader(request.Body, v)
+}
+
+func unmarshalReader(r io.Reader, v interface{}) error {
+	toByte, err := readerToByte(r)
+	if err != nil {
+		return errors.Wrap(err, "Failed to read body")
+	}
+	// Unmarshal into v if v is not a []byte o/w directly assign v to []byte
+	if _, ok := v.([]byte); !ok {
+		err = json.Unmarshal(toByte, v)
+		if err != nil {
+			return errors.Wrapf(err, "Failed unmarshal body")
+		}
+	} else {
+		v = toByte
+	}
+	return nil
+}

--- a/restclient/request_test.go
+++ b/restclient/request_test.go
@@ -1,0 +1,294 @@
+package restclient
+
+import (
+	"encoding/json"
+	"fmt"
+	. "github.com/smartystreets/goconvey/convey"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	testDataFormat = "%s - %s"
+	testSuccess    = "testSuccess"
+	testFailed     = "testFailed"
+)
+
+type testBasicAuthenticator struct {
+	username, password string
+}
+
+func newTestBasicAuthenticator(username, password string) Authenticator {
+	return &testBasicAuthenticator{
+		username: username,
+		password: password,
+	}
+}
+
+func (b testBasicAuthenticator) Apply(request *http.Request) error {
+	request.SetBasicAuth(b.username, b.password)
+	return nil
+}
+
+type testRequestBody struct {
+	TestId   int    `json:"test_id"`
+	TestName string `json:"test_name"`
+}
+
+type testHttpResponse struct {
+	StatusCode int         `json:"status_code"`
+	Data       interface{} `json:"data"`
+}
+
+func TestHttpClientRequests(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var response testHttpResponse
+		w.Header().Set("Content-Type", "application/json")
+
+		handleRequest := func(reqMethod string, statusCode int, resultString string) {
+			username, password, ok := r.BasicAuth()
+			if !ok || username != "detection" || password != "0123" {
+				statusCode = http.StatusUnauthorized
+				resultString = testFailed
+			}
+			response.StatusCode = statusCode
+			response.Data = fmt.Sprintf(testDataFormat, resultString, reqMethod)
+			w.WriteHeader(statusCode)
+		}
+
+		handleRequestWithBody := func(reqMethod string) {
+			status := http.StatusOK
+			resultString := testSuccess
+			var body testRequestBody
+			err := unmarshalRequestBody(r, &body)
+			if err != nil || body.TestName != "Testing Request Body" || body.TestId != 123 {
+				status = http.StatusBadRequest
+				resultString = testFailed
+			}
+			handleRequest(reqMethod, status, resultString)
+		}
+
+		switch r.Method {
+		case http.MethodGet:
+			handleRequest(http.MethodGet, http.StatusOK, testSuccess)
+		case http.MethodPost:
+			handleRequestWithBody(http.MethodPost)
+		case http.MethodPut:
+			handleRequestWithBody(http.MethodPut)
+		case http.MethodPatch:
+			handleRequestWithBody(http.MethodPatch)
+		case http.MethodDelete:
+			handleRequest(http.MethodDelete, http.StatusOK, testSuccess)
+		default:
+			response.StatusCode = http.StatusForbidden
+			response.Data = fmt.Sprintf(testDataFormat, testFailed, r.Method)
+		}
+		err := json.NewEncoder(w).Encode(response)
+		if err != nil {
+			log.Fatalf("httptest server failed to respond with testHttpResponse %v", err.Error())
+		}
+	}))
+	defer ts.Close()
+	// e.g. ts URL: http://127.0.0.1:63316
+	splittedURL := strings.Split(ts.URL, "://")
+	testServerScheme := splittedURL[0]
+	testServerHost := splittedURL[1]
+
+	Convey("TEST HTTP GET", t, func() {
+		var testResponse testHttpResponse
+		auth := newTestBasicAuthenticator("detection", "0123")
+		req, reqErr := RequestBuilder().
+			Scheme(testServerScheme).
+			Host(testServerHost).
+			Auth(auth).
+			ResponseReference(&testResponse).
+			Timeout(30 * time.Second).
+			LoggingEnabled(true).
+			Build()
+		if reqErr != nil {
+			log.Fatalf("failed to construct testRequest, %v", reqErr)
+		}
+
+		reqErr = req.Get()
+		Convey("Response should be fetched without any err and with proper Data", func() {
+			data, ok := testResponse.Data.(string)
+			So(reqErr, ShouldBeNil)
+			So(testResponse.StatusCode, ShouldEqual, http.StatusOK)
+			So(ok, ShouldBeTrue)
+			So(data, ShouldEqual, fmt.Sprintf(testDataFormat, testSuccess, http.MethodGet))
+		})
+	})
+
+	Convey("TEST HTTP GET with failing authentication credentials", t, func() {
+		var testResponse testHttpResponse
+		auth := newTestBasicAuthenticator("FAILING", "CREDENTIALS")
+		req, reqErr := RequestBuilder().
+			Scheme(testServerScheme).
+			Host(testServerHost).
+			Auth(auth).
+			ResponseReference(&testResponse).
+			Timeout(30 * time.Second).
+			LoggingEnabled(true).
+			Build()
+		if reqErr != nil {
+			log.Fatalf("failed to construct testRequest, %v", reqErr)
+		}
+
+		reqErr = req.Get()
+		Convey("Response should be fetched without any err and with proper Data", func() {
+			_, ok := testResponse.Data.(string)
+			So(ok, ShouldBeFalse)
+			So(testResponse.StatusCode, ShouldEqual, 0)
+			So(reqErr, ShouldNotBeNil)
+			So(reqErr.GetTopLevelError(), ShouldEqual, UnauthorizedErr)
+			So(reqErr.GetStatusCode(), ShouldEqual, http.StatusUnauthorized)
+		})
+	})
+
+	Convey("TEST HTTP POST with correct body", t, func() {
+		var testResponse testHttpResponse
+		testBody := testRequestBody{
+			TestId:   123,
+			TestName: "Testing Request Body",
+		}
+		auth := newTestBasicAuthenticator("detection", "0123")
+		req, reqErr := RequestBuilder().
+			Scheme(testServerScheme).
+			Host(testServerHost).
+			BodyJson(testBody).
+			Auth(auth).
+			ResponseReference(&testResponse).
+			Timeout(30 * time.Second).
+			LoggingEnabled(true).
+			Build()
+		if reqErr != nil {
+			log.Fatalf("failed to construct testRequest, %v", reqErr)
+		}
+
+		reqErr = req.Post()
+		Convey("Response should be fetched without any err and with proper Data", func() {
+			data, ok := testResponse.Data.(string)
+			So(reqErr, ShouldBeNil)
+			So(testResponse.StatusCode, ShouldEqual, http.StatusOK)
+			So(ok, ShouldBeTrue)
+			So(data, ShouldEqual, fmt.Sprintf(testDataFormat, testSuccess, http.MethodPost))
+		})
+	})
+
+	Convey("TEST HTTP POST with incorrect body", t, func() {
+		var testResponse testHttpResponse
+		testBody := "INCORRECT REQUEST BODY"
+		auth := newTestBasicAuthenticator("detection", "0123")
+		req, reqErr := RequestBuilder().
+			Scheme(testServerScheme).
+			Host(testServerHost).
+			BodyJson(testBody).
+			Auth(auth).
+			ResponseReference(&testResponse).
+			Timeout(30 * time.Second).
+			LoggingEnabled(true).
+			Build()
+		if reqErr != nil {
+			log.Fatalf("failed to construct testRequest, %v", reqErr)
+		}
+
+		reqErr = req.Post()
+		Convey("Response should be fetched without any err and with proper Data", func() {
+			_, ok := testResponse.Data.(string)
+			So(ok, ShouldBeFalse)
+			So(testResponse.StatusCode, ShouldEqual, 0)
+			So(reqErr, ShouldNotBeNil)
+			So(reqErr.GetTopLevelError(), ShouldEqual, ParseErr)
+			So(reqErr.GetStatusCode(), ShouldEqual, http.StatusBadRequest)
+		})
+	})
+
+	Convey("TEST HTTP PUT with correct body", t, func() {
+		var testResponse testHttpResponse
+		testBody := testRequestBody{
+			TestId:   123,
+			TestName: "Testing Request Body",
+		}
+		auth := newTestBasicAuthenticator("detection", "0123")
+		req, reqErr := RequestBuilder().
+			Scheme(testServerScheme).
+			Host(testServerHost).
+			BodyJson(testBody).
+			Auth(auth).
+			ResponseReference(&testResponse).
+			Timeout(30 * time.Second).
+			LoggingEnabled(true).
+			Build()
+		if reqErr != nil {
+			log.Fatalf("failed to construct testRequest, %v", reqErr)
+		}
+
+		reqErr = req.Put()
+		Convey("Response should be fetched without any err and with proper Data", func() {
+			data, ok := testResponse.Data.(string)
+			So(reqErr, ShouldBeNil)
+			So(testResponse.StatusCode, ShouldEqual, http.StatusOK)
+			So(ok, ShouldBeTrue)
+			So(data, ShouldEqual, fmt.Sprintf(testDataFormat, testSuccess, http.MethodPut))
+		})
+	})
+
+	Convey("TEST HTTP PATCH with correct body", t, func() {
+		var testResponse testHttpResponse
+		testBody := testRequestBody{
+			TestId:   123,
+			TestName: "Testing Request Body",
+		}
+		auth := newTestBasicAuthenticator("detection", "0123")
+		req, reqErr := RequestBuilder().
+			Scheme(testServerScheme).
+			Host(testServerHost).
+			BodyJson(testBody).
+			Auth(auth).
+			ResponseReference(&testResponse).
+			Timeout(30 * time.Second).
+			LoggingEnabled(true).
+			Build()
+		if reqErr != nil {
+			log.Fatalf("failed to construct testRequest, %v", reqErr)
+		}
+
+		reqErr = req.Patch()
+		Convey("Response should be fetched without any err and with proper Data", func() {
+			data, ok := testResponse.Data.(string)
+			So(reqErr, ShouldBeNil)
+			So(testResponse.StatusCode, ShouldEqual, http.StatusOK)
+			So(ok, ShouldBeTrue)
+			So(data, ShouldEqual, fmt.Sprintf(testDataFormat, testSuccess, http.MethodPatch))
+		})
+	})
+
+	Convey("TEST HTTP DELETE", t, func() {
+		var testResponse testHttpResponse
+		auth := newTestBasicAuthenticator("detection", "0123")
+		req, reqErr := RequestBuilder().
+			Scheme(testServerScheme).
+			Host(testServerHost).
+			Auth(auth).
+			ResponseReference(&testResponse).
+			Timeout(30 * time.Second).
+			LoggingEnabled(true).
+			Build()
+		if reqErr != nil {
+			log.Fatalf("failed to construct testRequest, %v", reqErr)
+		}
+
+		reqErr = req.Delete()
+		Convey("Response should be fetched without any err and with proper Data", func() {
+			data, ok := testResponse.Data.(string)
+			So(reqErr, ShouldBeNil)
+			So(testResponse.StatusCode, ShouldEqual, http.StatusOK)
+			So(ok, ShouldBeTrue)
+			So(data, ShouldEqual, fmt.Sprintf(testDataFormat, testSuccess, http.MethodDelete))
+		})
+	})
+}

--- a/restclient/v1/client.go
+++ b/restclient/v1/client.go
@@ -1,10 +1,11 @@
-package restclient
+package v1
 
 import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
 	"github.com/pkg/errors"
+	"github.com/ysyesilyurt/go-restclient/restclient"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -49,12 +50,12 @@ func NewHttpClient(loggingEnabled bool, timeout time.Duration) HttpClient {
 
 type DoRequestInfo struct {
 	request        *http.Request
-	auth           Authenticator
+	auth           restclient.Authenticator
 	respRef        interface{}
 	requestTimeout time.Duration
 }
 
-func NewDoRequestInfo(request *http.Request, auth Authenticator, responseReference interface{}) DoRequestInfo {
+func NewDoRequestInfo(request *http.Request, auth restclient.Authenticator, responseReference interface{}) DoRequestInfo {
 	return DoRequestInfo{
 		request: request,
 		auth:    auth,
@@ -64,7 +65,7 @@ func NewDoRequestInfo(request *http.Request, auth Authenticator, responseReferen
 
 /* NewDoRequestInfoWithTimeout creates a DoRequestInfo with given requestTimeout. Should be used whenever a specific
 timeout value is required for individual request. Will override HttpClient timeout value when smaller, otherwise will have no effect. */
-func NewDoRequestInfoWithTimeout(request *http.Request, auth Authenticator, responseReference interface{}, requestTimeout time.Duration) DoRequestInfo {
+func NewDoRequestInfoWithTimeout(request *http.Request, auth restclient.Authenticator, responseReference interface{}, requestTimeout time.Duration) DoRequestInfo {
 	return DoRequestInfo{
 		request:        request,
 		auth:           auth,
@@ -103,7 +104,7 @@ func (hc HttpClient) Delete(dri DoRequestInfo) error {
 	return hc.do(dri.request, http.MethodDelete, dri.auth, dri.respRef, dri.requestTimeout)
 }
 
-func (hc HttpClient) do(req *http.Request, method string, auth Authenticator, respRef interface{}, timeout time.Duration) error {
+func (hc HttpClient) do(req *http.Request, method string, auth restclient.Authenticator, respRef interface{}, timeout time.Duration) error {
 
 	setHeaderIfNotSetAlready := func(key, value string) {
 		if req.Header.Get(key) == "" && value != "" {

--- a/restclient/v1/client_test.go
+++ b/restclient/v1/client_test.go
@@ -1,9 +1,10 @@
-package restclient
+package v1
 
 import (
 	"encoding/json"
 	"fmt"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/ysyesilyurt/go-restclient/restclient"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -22,7 +23,7 @@ type testBasicAuthenticator struct {
 	Username, Password string
 }
 
-func NewTestBasicAuthenticator(username, password string) Authenticator {
+func NewTestBasicAuthenticator(username, password string) restclient.Authenticator {
 	return &testBasicAuthenticator{
 		Username: username,
 		Password: password,

--- a/restclient/v1/logger.go
+++ b/restclient/v1/logger.go
@@ -1,4 +1,4 @@
-package restclient
+package v1
 
 import (
 	"fmt"

--- a/restclient/v1/request.go
+++ b/restclient/v1/request.go
@@ -1,4 +1,4 @@
-package restclient
+package v1
 
 import (
 	"bytes"

--- a/restclient/v1/request_test.go
+++ b/restclient/v1/request_test.go
@@ -1,4 +1,4 @@
-package restclient
+package v1
 
 import (
 	"bytes"

--- a/restclient/v1/wrappers.go
+++ b/restclient/v1/wrappers.go
@@ -1,7 +1,8 @@
-package restclient
+package v1
 
 import (
 	"github.com/pkg/errors"
+	"github.com/ysyesilyurt/go-restclient/restclient"
 	"net/http"
 	"time"
 )
@@ -10,7 +11,7 @@ import (
 
 /* PerformGetRequest creates a http.Request and a HttpClient with given timeout value,
 then performs a HTTP GET request using provided Authenticator. Decodes any response to responseReference */
-func PerformGetRequest(ri RequestInfo, auth Authenticator, responseReference interface{}, loggingEnabled bool, timeout time.Duration) error {
+func PerformGetRequest(ri RequestInfo, auth restclient.Authenticator, responseReference interface{}, loggingEnabled bool, timeout time.Duration) error {
 	req, client, err := newRequestAndClient(ri, loggingEnabled, timeout)
 	if err != nil {
 		return errors.Wrap(err, "Could not create request and client")
@@ -21,7 +22,7 @@ func PerformGetRequest(ri RequestInfo, auth Authenticator, responseReference int
 
 /* PerformPostRequest creates a http.Request and a HttpClient with given timeout value,
 then performs a HTTP POST request using provided Authenticator. Decodes any response to responseReference */
-func PerformPostRequest(ri RequestInfo, auth Authenticator, responseReference interface{}, loggingEnabled bool, timeout time.Duration) error {
+func PerformPostRequest(ri RequestInfo, auth restclient.Authenticator, responseReference interface{}, loggingEnabled bool, timeout time.Duration) error {
 	req, client, err := newRequestAndClient(ri, loggingEnabled, timeout)
 	if err != nil {
 		return errors.Wrap(err, "Could not create request and client")
@@ -32,7 +33,7 @@ func PerformPostRequest(ri RequestInfo, auth Authenticator, responseReference in
 
 /* PerformPutRequest creates a http.Request and a HttpClient with given timeout value,
 then performs a HTTP PUT request using provided Authenticator. Decodes any response to responseReference */
-func PerformPutRequest(ri RequestInfo, auth Authenticator, responseReference interface{}, loggingEnabled bool, timeout time.Duration) error {
+func PerformPutRequest(ri RequestInfo, auth restclient.Authenticator, responseReference interface{}, loggingEnabled bool, timeout time.Duration) error {
 	req, client, err := newRequestAndClient(ri, loggingEnabled, timeout)
 	if err != nil {
 		return errors.Wrap(err, "Could not create request and client")
@@ -43,7 +44,7 @@ func PerformPutRequest(ri RequestInfo, auth Authenticator, responseReference int
 
 /* PerformPatchRequest creates a http.Request and a HttpClient with given timeout value,
 then performs a HTTP PATCH request using provided Authenticator. Decodes any response to responseReference */
-func PerformPatchRequest(ri RequestInfo, auth Authenticator, responseReference interface{}, loggingEnabled bool, timeout time.Duration) error {
+func PerformPatchRequest(ri RequestInfo, auth restclient.Authenticator, responseReference interface{}, loggingEnabled bool, timeout time.Duration) error {
 	req, client, err := newRequestAndClient(ri, loggingEnabled, timeout)
 	if err != nil {
 		return errors.Wrap(err, "Could not create request and client")
@@ -54,7 +55,7 @@ func PerformPatchRequest(ri RequestInfo, auth Authenticator, responseReference i
 
 /* PerformDeleteRequest creates a http.Request and a HttpClient with given timeout value,
 then performs a HTTP DELETE request using provided Authenticator. Decodes any response to responseReference */
-func PerformDeleteRequest(ri RequestInfo, auth Authenticator, responseReference interface{}, loggingEnabled bool, timeout time.Duration) error {
+func PerformDeleteRequest(ri RequestInfo, auth restclient.Authenticator, responseReference interface{}, loggingEnabled bool, timeout time.Duration) error {
 	req, client, err := newRequestAndClient(ri, loggingEnabled, timeout)
 	if err != nil {
 		return errors.Wrap(err, "Could not create request and client")


### PR DESCRIPTION
Now requests can be built using awesome Builder Pattern. The implementation contains a builder constructor `restclient.RequestBuilder()` and lots of builder methods to build resulting request. Example of such a usage:

```
req, reqErr := restclient.RequestBuilder().
		RawUrl(rawUrl).
		Header(&headers).
		Auth(testAuth).
		ResponseReference(&response).
		LoggingEnabled(true).
		Timeout(30 * time.Second).
		Build()

if reqErr != nil {
	return errors.Wrap(reqErr, "Failed to construct HTTP request")
}

reqErr = req.Get()
if reqErr != nil {
	return errors.Wrap(reqErr, "Failed to perform HTTP GET request")
}
return nil
```